### PR TITLE
Fix incorrect docs

### DIFF
--- a/src/circuit.mli
+++ b/src/circuit.mli
@@ -35,8 +35,8 @@ module Config : sig
     (** Map over circuit outputs just before constructing the circuit. *)
     }
 
-  (** Perform combination loop checking, normalize uids, [Relaxed] port checks, and add
-      phantom inputs. *)
+  (** Perform combination loop checking, normalize uids, [Port_sets_and_widths] port checks,
+      and add phantom inputs. *)
   val default : t
 end
 


### PR DESCRIPTION
This is the new default: https://github.com/SUPERCILEX/hardcaml/blob/567efac648fb93367bc4d3453e4d1cd18695002b/src/circuit.ml#L73